### PR TITLE
Fix typo in webpack peerDependency version constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "webpack": "^4.0.0"
     },
     "peerDependencies": {
-        "webpack": "^3.0.0 | ^4.0.0 | '^5.0.0"
+        "webpack": "^3.0.0 | ^4.0.0 | ^5.0.0"
     },
     "dependencies": {
         "axios": "^0.21.1"


### PR DESCRIPTION
There's an extra `'` in the version constraint which causes npm installs/updates to fail, this PR just removes it.