### PR TITLE
Fix webpack version constraint again

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "webpack": "^4.0.0"
     },
     "peerDependencies": {
-        "webpack": "^3.0.0 | ^4.0.0 | ^5.0.0"
+        "webpack": "^3.0.0 || ^4.0.0 || ^5.0.0"
     },
     "dependencies": {
         "axios": "^0.21.1"


### PR DESCRIPTION
This PR fixes the syntax of the webpack peerDependency version constraint.

According to both [the `semver` docs](https://github.com/npm/node-semver#ranges) and [my own debugging](https://replit.com/@bakerkretzmar/RudeNavajowhiteHashmap#index.js), `|` is not recognized as a valid version range separator, only `||` is.